### PR TITLE
Adjusting css to fix tab panel colorization [2024.03.31]

### DIFF
--- a/browser/base/content/browser-favicon-color.js
+++ b/browser/base/content/browser-favicon-color.js
@@ -116,17 +116,28 @@ function setFaviconColorToTitlebar() {
       let textColor =
         result.averageColor - 0x222222 > 0xffffff / 2 ? "#000000" : "#ffffff";
       let CSS = `
-        #navigator-toolbox:not(:-moz-lwtheme), #navigator-toolbox:-moz-lwtheme {
-          background-color: ${result.averageColor} !important;
+        :root {
+            --floorp-tab-panel-bg-color: ${result.averageColor};
+            --floorp-tab-panel-fg-color: ${textColor};
+            
+            --floorp-navigator-toolbox-bg-color: var(--floorp-tab-panel-bg-color);
+            --floorp-tab-label-fg-color: var(--floorp-tab-panel-fg-color);
+            --floorp-tabs-icons-fg-color: var(--floorp-tab-panel-fg-color);
+        }
+      
+        #browser #TabsToolbar,
+        #navigator-toolbox:not(:-moz-lwtheme),
+        #navigator-toolbox:-moz-lwtheme {
+          background-color: var(--floorp-navigator-toolbox-bg-color) !important;
         }
 
         .tab-label:not([selected="true"]) {
-          color: ${textColor} !important;
+          color: var(--floorp-tab-label-fg-color) !important;
         }
 
         .tab-icon-stack > * , #TabsToolbar-customization-target > *, #tabs-newtab-button, .titlebar-color > * {
-          color: ${textColor} !important;
-          fill: ${textColor} !important;
+          color: var(--floorp-tabs-icons-fg-color) !important;
+          fill: var(--floorp-tabs-icons-fg-color) !important;
         }
       `;
       elem.textContent = CSS;


### PR DESCRIPTION
### Check list

- [x] Referenced all related issues
- [x] Have tested the modifications
- [x] Allow Floorp to use the modifications under the Floorp SHARED SOURCE LICENSE & MIT License

Fix of the bug:
[Floorp toolbar colorization bug +suggestion of fix · Issue #3 · Floorp-Projects/Floorp-private-components⁠ ⁢⁢ ⁢⁢⁢](https://github.com/Floorp-Projects/Floorp-private-components/issues/3)
This bug reproduces on vertical tabs without TreeStyleTab extension.