### PR TITLE
Fix getting the selected icon

### DIFF
--- a/browser/base/content/browser-favicon-color.mjs
+++ b/browser/base/content/browser-favicon-color.mjs
@@ -125,9 +125,7 @@ const gFloorpFaviconColor = {
   },
 
   setFaviconColorToTitlebar() {
-    const base64Image = document.querySelector(
-      '.tab-icon-image[selected="true"]'
-    )?.src;
+    const base64Image = gBrowser.selectedTab.querySelector('.tab-icon-image')?.src;
     const base64ImageWithoutHeader = base64Image?.split(",")[1];
 
     gFloorpFaviconColor


### PR DESCRIPTION
When the event `floorpOnLocationChangeEvent` is received, an incorrect icon is selected because of a long DOM update. `gBrowser.selectedTab` has more up-to-date information.

- [x] Referenced all related issues
- [x] Have tested the modifications
- [x] Allow Floorp to use the modifications under the Floorp SHARED SOURCE LICENSE & MIT License

